### PR TITLE
Create 'info box' beneath docs content

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -55,7 +55,8 @@ const config = {
         docs: {
           routeBasePath: '/',
           sidebarPath: require.resolve('./sidebars.js'),
-          editUrl: 'https://github.com/radicle-dev/radicle-docs/blob/master/',
+          editUrl: 'https://github.com/radicle-dev/radicle-docs/blob/main/',
+          showLastUpdateTime: true,
         },
         blog: false,
         theme: {

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -48,6 +48,8 @@
   --ifm-color-primary-lighter: #8888ff;
   --ifm-color-primary-lightest: #bbbbff;
 
+  --ifm-color-secondary: #53DB53;
+
   --ifm-background-color: #f3f6fd; 
   --ifm-navbar-background-color: #F8F8F8;
   --ifm-footer-background-color: #e3e3f3;

--- a/src/theme/DocItem/Footer/index.js
+++ b/src/theme/DocItem/Footer/index.js
@@ -79,7 +79,7 @@ export default function DocItemFooter() {
             <p>{editUrl && <EditThisPage editUrl={editUrl} />}</p>
             <p>
               <span className={styles.infoBoxIcon}>🤝</span> 
-              <Link to={'#'}>
+              <Link to={'/community/stay-up-to-date'}>
                 Stay up to date
               </Link>
             </p>
@@ -88,16 +88,16 @@ export default function DocItemFooter() {
             <p className={styles.infoBoxHeader}>Need help?</p>
             <p>
               <span className={styles.infoBoxIcon}>💬</span> 
-              <Link to={'#'}>
+              <Link to={'https://discord.gg/radicle'}>
                 Find us on Discord
               </Link>
             </p>
-            <p>
+            {/* <p>
               <span className={styles.infoBoxIcon}>🧭</span> 
               <Link to={'#'}>
                 Another link
               </Link>
-            </p>
+            </p> */}
           </div>
         </div>
       </div>

--- a/src/theme/DocItem/Footer/index.js
+++ b/src/theme/DocItem/Footer/index.js
@@ -63,7 +63,7 @@ export default function DocItemFooter() {
       <div className={styles.infoBox}>
         <div className="row">
           <div className="col">
-            <p className={styles.infoBoxHeader}>About this doc</p>
+            <h3>About this doc</h3>
             <p>
               {(lastUpdatedAt || lastUpdatedBy) && (
                 <LastUpdated
@@ -75,23 +75,25 @@ export default function DocItemFooter() {
             </p>
           </div>
           <div className="col">
-            <p className={styles.infoBoxHeader}>Contribute</p>
-            <p>{editUrl && <EditThisPage editUrl={editUrl} />}</p>
-            <p>
-              <span className={styles.infoBoxIcon}>🤝</span> 
+            <h3>Contribute</h3>
+            <div className={styles.infoBoxLink}>
+              {editUrl && <EditThisPage editUrl={editUrl} />}
+            </div>
+            <div className={styles.infoBoxLink}>
+              {/* <span className={styles.infoBoxIcon}>🤝</span>  */}
               <Link to={'/community/stay-up-to-date'}>
                 Stay up to date
               </Link>
-            </p>
+            </div>
           </div>
           <div className="col">
-            <p className={styles.infoBoxHeader}>Need help?</p>
-            <p>
-              <span className={styles.infoBoxIcon}>💬</span> 
+            <h3>Need help?</h3>
+            <div className={styles.infoBoxLink}>
+              {/* <span className={styles.infoBoxIcon}>💬</span>  */}
               <Link to={'https://discord.gg/radicle'}>
                 Find us on Discord
               </Link>
-            </p>
+            </div>
             {/* <p>
               <span className={styles.infoBoxIcon}>🧭</span> 
               <Link to={'#'}>

--- a/src/theme/DocItem/Footer/index.js
+++ b/src/theme/DocItem/Footer/index.js
@@ -1,12 +1,16 @@
 import React from 'react';
 import clsx from 'clsx';
-import Link from '@docusaurus/Link';
 import {ThemeClassNames} from '@docusaurus/theme-common';
 import {useDoc} from '@docusaurus/theme-common/internal';
 import LastUpdated from '@theme/LastUpdated';
 import EditThisPage from '@theme/EditThisPage';
 import TagsListInline from '@theme/TagsListInline';
 import styles from './styles.module.css';
+
+// BEGIN MODIFICATIONS
+import Link from '@docusaurus/Link';
+// END MODIFICATIONS
+
 function TagsRow(props) {
   return (
     <div
@@ -55,6 +59,7 @@ export default function DocItemFooter() {
   return (
     <footer
       className={clsx(ThemeClassNames.docs.docFooter, 'docusaurus-mt-lg')}>
+      {/* BEGIN MODIFICATIONS */}
       <div className={styles.infoBox}>
         <div className="row">
           <div className="col">
@@ -95,7 +100,6 @@ export default function DocItemFooter() {
             </p>
           </div>
         </div>
-        
       </div>
       {/* {canDisplayTagsRow && <TagsRow tags={tags} />}
       {canDisplayEditMetaRow && (
@@ -106,6 +110,7 @@ export default function DocItemFooter() {
           formattedLastUpdatedAt={formattedLastUpdatedAt}
         />
       )} */}
+      {/* END MODIFICATIONS */}
     </footer>
   );
 }

--- a/src/theme/DocItem/Footer/index.js
+++ b/src/theme/DocItem/Footer/index.js
@@ -1,0 +1,111 @@
+import React from 'react';
+import clsx from 'clsx';
+import Link from '@docusaurus/Link';
+import {ThemeClassNames} from '@docusaurus/theme-common';
+import {useDoc} from '@docusaurus/theme-common/internal';
+import LastUpdated from '@theme/LastUpdated';
+import EditThisPage from '@theme/EditThisPage';
+import TagsListInline from '@theme/TagsListInline';
+import styles from './styles.module.css';
+function TagsRow(props) {
+  return (
+    <div
+      className={clsx(
+        ThemeClassNames.docs.docFooterTagsRow,
+        'row margin-bottom--sm',
+      )}>
+      <div className="col">
+        <TagsListInline {...props} />
+      </div>
+    </div>
+  );
+}
+function EditMetaRow({
+  editUrl,
+  lastUpdatedAt,
+  lastUpdatedBy,
+  formattedLastUpdatedAt,
+}) {
+  return (
+    <div className={clsx(ThemeClassNames.docs.docFooterEditMetaRow, 'row')}>
+      <div className="col">{editUrl && <EditThisPage editUrl={editUrl} />}</div>
+
+      <div className={clsx('col', styles.lastUpdated)}>
+        {(lastUpdatedAt || lastUpdatedBy) && (
+          <LastUpdated
+            lastUpdatedAt={lastUpdatedAt}
+            formattedLastUpdatedAt={formattedLastUpdatedAt}
+            lastUpdatedBy={lastUpdatedBy}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+export default function DocItemFooter() {
+  const {metadata} = useDoc();
+  const {editUrl, lastUpdatedAt, formattedLastUpdatedAt, lastUpdatedBy, tags} =
+    metadata;
+  const canDisplayTagsRow = tags.length > 0;
+  const canDisplayEditMetaRow = !!(editUrl || lastUpdatedAt || lastUpdatedBy);
+  const canDisplayFooter = canDisplayTagsRow || canDisplayEditMetaRow;
+  if (!canDisplayFooter) {
+    return null;
+  }
+  return (
+    <footer
+      className={clsx(ThemeClassNames.docs.docFooter, 'docusaurus-mt-lg')}>
+      <div className={styles.infoBox}>
+        <div className="row">
+          <div className="col">
+            <p className={styles.infoBoxHeader}>About this doc</p>
+            <p>
+              {(lastUpdatedAt || lastUpdatedBy) && (
+                <LastUpdated
+                  lastUpdatedAt={lastUpdatedAt}
+                  formattedLastUpdatedAt={formattedLastUpdatedAt}
+                  lastUpdatedBy={lastUpdatedBy}
+                />
+              )}
+            </p>
+          </div>
+          <div className="col">
+            <p className={styles.infoBoxHeader}>Contribute</p>
+            <p>{editUrl && <EditThisPage editUrl={editUrl} />}</p>
+            <p>
+              <span className={styles.infoBoxIcon}>🤝</span> 
+              <Link to={'#'}>
+                Stay up to date
+              </Link>
+            </p>
+          </div>
+          <div className="col">
+            <p className={styles.infoBoxHeader}>Need help?</p>
+            <p>
+              <span className={styles.infoBoxIcon}>💬</span> 
+              <Link to={'#'}>
+                Find us on Discord
+              </Link>
+            </p>
+            <p>
+              <span className={styles.infoBoxIcon}>🧭</span> 
+              <Link to={'#'}>
+                Another link
+              </Link>
+            </p>
+          </div>
+        </div>
+        
+      </div>
+      {/* {canDisplayTagsRow && <TagsRow tags={tags} />}
+      {canDisplayEditMetaRow && (
+        <EditMetaRow
+          editUrl={editUrl}
+          lastUpdatedAt={lastUpdatedAt}
+          lastUpdatedBy={lastUpdatedBy}
+          formattedLastUpdatedAt={formattedLastUpdatedAt}
+        />
+      )} */}
+    </footer>
+  );
+}

--- a/src/theme/DocItem/Footer/styles.module.css
+++ b/src/theme/DocItem/Footer/styles.module.css
@@ -13,28 +13,47 @@
 /* BEGIN MODIFICATIONS */
 
 .infoBox {
-  background: #5555FF;
-  border-radius: 0.75rem;
-  padding: 2rem 3rem;
+  background: #fff;
+  box-shadow: 24px 20px 68px 0px rgba(0, 0, 0, .25);
+  border-radius: 4px 4px 32px 32px;
+  padding: 2rem;
   margin: 5rem 0;
-  box-shadow: 0px 27px 58px rgba(0, 0, 0, 0.07), 0px 12.4829px 26.8152px rgba(0, 0, 0, 0.0519173), 0px 7.14244px 15.343px rgba(0, 0, 0, 0.0438747), 0px 4.33541px 9.3131px rgba(0, 0, 0, 0.0377964), 0px 2.61228px 5.61156px rgba(0, 0, 0, 0.0322036), 0px 1.45468px 3.12488px rgba(0, 0, 0, 0.0261253), 0px 0.62565px 1.34399px rgba(0, 0, 0, 0.0180827);
 }
 
 .infoBox p {
-  color: white;
+  color: var(--ifm-font-color-base);
   margin-bottom: 0.6rem;
   vertical-align: middle;
 }
 
 .infoBox p a {
-  color: white;
+  color: var(--ifm-font-color-base);
   font-weight: 500;
 }
 
-p.infoBoxHeader {
-  font-size: 1.3rem;
-  font-weight: 700;
-  margin-bottom: 1.2rem;
+.infoBoxLink {
+  display: inline-block;
+  position: relative;
+  background-color: var(--ifm-color-secondary);
+  color: var(--ifm-font-color-base);
+  font-family: var(--ifm-heading-font-family);
+  font-size: 1.5rem;
+  line-height: 1;
+  border: none !important;
+  border-radius: 8px;
+  padding: 8px 12px;
+  margin-bottom: 0.6rem;
+  transition: transform .15s ease-in-out, box-shadow .15s ease-in-out;
+}
+
+.infoBoxLink:last-of-type {
+  margin-bottom: 0;
+}
+
+.infoBoxLink:hover  {
+  transform: translateY(-4px);
+  box-shadow: 0 4px 0 #569656;
+  text-decoration: none;
 }
 
 .infoBoxIcon {

--- a/src/theme/DocItem/Footer/styles.module.css
+++ b/src/theme/DocItem/Footer/styles.module.css
@@ -10,6 +10,8 @@
   }
 }
 
+/* BEGIN MODIFICATIONS */
+
 .infoBox {
   background: #5555FF;
   border-radius: 0.75rem;
@@ -36,6 +38,7 @@ p.infoBoxHeader {
 }
 
 .infoBoxIcon {
-  /* font-size: 1.4rem; */
   margin-right: 0.4rem;
 }
+
+/* END MODIFICATIONS */

--- a/src/theme/DocItem/Footer/styles.module.css
+++ b/src/theme/DocItem/Footer/styles.module.css
@@ -1,0 +1,41 @@
+.lastUpdated {
+  margin-top: 0.2rem;
+  font-style: italic;
+  font-size: smaller;
+}
+
+@media (min-width: 997px) {
+  .lastUpdated {
+    text-align: right;
+  }
+}
+
+.infoBox {
+  background: #5555FF;
+  border-radius: 0.75rem;
+  padding: 2rem 3rem;
+  margin: 5rem 0;
+  box-shadow: 0px 27px 58px rgba(0, 0, 0, 0.07), 0px 12.4829px 26.8152px rgba(0, 0, 0, 0.0519173), 0px 7.14244px 15.343px rgba(0, 0, 0, 0.0438747), 0px 4.33541px 9.3131px rgba(0, 0, 0, 0.0377964), 0px 2.61228px 5.61156px rgba(0, 0, 0, 0.0322036), 0px 1.45468px 3.12488px rgba(0, 0, 0, 0.0261253), 0px 0.62565px 1.34399px rgba(0, 0, 0, 0.0180827);
+}
+
+.infoBox p {
+  color: white;
+  margin-bottom: 0.6rem;
+  vertical-align: middle;
+}
+
+.infoBox p a {
+  color: white;
+  font-weight: 500;
+}
+
+p.infoBoxHeader {
+  font-size: 1.3rem;
+  font-weight: 700;
+  margin-bottom: 1.2rem;
+}
+
+.infoBoxIcon {
+  /* font-size: 1.4rem; */
+  margin-right: 0.4rem;
+}


### PR DESCRIPTION
In the Figma designs for the new docs structure, @shelbeeee requested we build a box that goes at the bottom of every doc with some helpful links. The new structure is being worked on, but I ended up taking a swing at implementing the box itself.

A screenshot of the current implementation:

![Screenshot 2023-04-19 at 11-45-02 Obtaining $RAD RadicleDAO Documentation](https://user-images.githubusercontent.com/1153921/233189382-af7ff93d-282e-460f-a469-48aebd7e9f5b.png)

The `Last updated...` and `Edit this page` sections can't really be changed, but all other design/copy/links are customizable—I figure I'll update those once the new structure is merged.